### PR TITLE
Fix LED driver includes for demo

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,3 +1,6 @@
-idf_component_register(SRCS "hello_world_main.cpp"
-                       PRIV_REQUIRES spi_flash
-                       INCLUDE_DIRS ".")
+idf_component_register(
+    SRCS "hello_world_main.cpp"
+    PRIV_REQUIRES spi_flash
+    REQUIRES hf-ws2812-rmt-driver
+    INCLUDE_DIRS "." "../hf-hal/utils-and-drivers/hf-core-drivers/internal/hf-pincfg/include"
+)

--- a/main/hello_world_main.cpp
+++ b/main/hello_world_main.cpp
@@ -8,11 +8,11 @@
 #include "esp_flash.h"
 #include "esp_system.h"
 
-#include "ws2812_cpp.hpp" // Include the WS2812 strip header
-#include "ws2812_effects.hpp" // Include the WS2812 animator header
-#include "../HAL/PinCfg/gpio_config_esp32c6.hpp" // Include the GPIO configuration header
+#include "ws2812_cpp.hpp"              // WS2812 strip wrapper
+#include "ws2812_effects.hpp"          // Basic LED animation helpers
+#include "hf_gpio_config.hpp"          // Board pin configuration
 
-WS2812Strip strip(WS2812_LED_PIN, RMT_CHANNEL_0, 30, LedType::RGB); // Use WS2812_LED_PIN from gpio_config_esp32c6.hpp
+WS2812Strip strip(WS2812_LED_PIN, RMT_CHANNEL_0, 30, LedType::RGB); // LED pin from hf_gpio_config.hpp
 WS2812Animator anim(strip);
 
 void printChipInfo(void)


### PR DESCRIPTION
## Summary
- include hf_gpio_config for pin definitions
- depend on hf-ws2812 driver component